### PR TITLE
Scheme checks fixes

### DIFF
--- a/database_scheme.sql
+++ b/database_scheme.sql
@@ -22,8 +22,9 @@ CREATE TABLE users
 CREATE TABLE conversations
 (
     client_chat_id   integer NOT NULL UNIQUE REFERENCES users,
-    /* `operator_chat_id` being `NULL` indicates that the client is waiting for an invitation to be accepted. */
-    operator_chat_id integer UNIQUE REFERENCES users
+    operator_chat_id integer UNIQUE REFERENCES users, /* `operator_chat_id` being `NULL` indicates that the client is
+                                                         waiting for an invitation to be accepted. */
+    CONSTRAINT client_and_operator_are_different CHECK ( client_chat_id <> operator_chat_id )
 );
 
 /*
@@ -39,7 +40,8 @@ CREATE TABLE reflected_messages
     interlocutor1_chat_id    integer NOT NULL REFERENCES users,
     interlocutor1_message_id integer NOT NULL,
     interlocutor2_chat_id    integer NOT NULL REFERENCES users,
-    interlocutor2_message_id integer NOT NULL
+    interlocutor2_message_id integer NOT NULL,
+    CONSTRAINT interlocutors_are_different CHECK ( interlocutor1_chat_id <> interlocutor2_chat_id )
 );
 
 /*
@@ -56,35 +58,3 @@ CREATE TABLE sent_invitations
     invitation_message_id integer NOT NULL,
     UNIQUE (operator_chat_id, client_chat_id)
 );
-
-
-CREATE FUNCTION user_is_operator(integer) RETURNS boolean
-AS
-'SELECT is_operator
- FROM users
- WHERE chat_id = $1' LANGUAGE SQL VOLATILE;
-
-CREATE FUNCTION operator_is_operating(integer) RETURNS boolean
-AS
-'SELECT exists(SELECT 1
-               FROM conversations
-               WHERE operator_chat_id = $1)' LANGUAGE SQL VOLATILE;
-
-CREATE FUNCTION operator_is_crying(integer) RETURNS boolean
-AS
-'SELECT exists(SELECT 1
-               FROM conversations
-               WHERE client_chat_id = $1)'
-    LANGUAGE SQL VOLATILE;
-
-
-ALTER TABLE conversations
-    ADD CONSTRAINT client_is_not_operating CHECK ( NOT user_is_operator(client_chat_id) OR
-                                                   NOT operator_is_operating(client_chat_id) );
-
-ALTER TABLE conversations
-    ADD CONSTRAINT operator_is_operator_and_is_not_crying CHECK ( user_is_operator(operator_chat_id) AND
-                                                                  NOT operator_is_crying(operator_chat_id) );
-
-ALTER TABLE conversations
-    ADD CONSTRAINT client_and_operator_are_different CHECK ( client_chat_id <> operator_chat_id );


### PR DESCRIPTION
Moved the `conversations`' `client_and_operator_are_different` constraints declaration to the table declaration, added a similar `interlocutors_are_different` to the `reflected_messages` table.
Removed other `CHECK`s (violating PostgreSQL's rules) and procedures used for them: what they were intended for should now be handled by the python code in core.

Fixes #36

~~Is blocked by #44.~~ Might be made a PR to master - if #45 is resolved earlier